### PR TITLE
Fix META file

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,7 +1,7 @@
 {
-    "perl"        : "6",
+    "perl"        : "6.*",
     "name"        : "IRC::TextColor",
-    "version"     : "v0.1.1",
+    "version"     : "0.1.1",
     "authors"	  : ["Samantha McVey"],
     "description" : "Color/Style text for IRC, and convert ANSI color from terminals into IRC coloring",
     "source-url"  : "git://github.com/samcv/IRC-TextColor.git",


### PR DESCRIPTION
The `v` with version in metafile means it's part of your actual version number, so it'd be `use Blah:ver<v1.10>` instead of just `1.10`.

The `perl` field indicates the minimum required language version and `6` is `after` `6.c` and will never be released. Once the module installers actually start paying attention to this field, your module will be uninstallable.

There's also [Test::META module](http://modules.perl6.org/repo/Test::META) that can find errors in your meta.

P.S.: `META.info` is the old, pre-first-stable-release format. The new format for meta file is to be named `META6.json`. While we'll support both for probably quite a while, it'd be nice not to let the outdated name spread around.