### PR TITLE
Accept any type as "text"

### DIFF
--- a/IRC/TextColor.pm6
+++ b/IRC/TextColor.pm6
@@ -59,15 +59,15 @@ my %ansi-back-colors =
 	light_cyan => "46",
 	white   => "47",
 	default => "49";
-sub irc-style-char ( Str $style ) is export {
+sub irc-style-char ( Str() $style ) is export {
 	return %irc-styles{$style} if %irc-styles{$style};
 }
-sub irc-color-start ( Str $color ) is export {
+sub irc-color-start ( Str() $color ) is export {
 	return %irc-styles{'color'} ~ %irc-colors{$color} if %irc-colors{$color};
 }
 #| a shortened function. Like irc-style-text but you can use shorter versions like
 #| C<ircstyle('text', :bold, :green)
-sub ircstyle ( Str $text, *%args ) is export {
+sub ircstyle ( Str() $text, *%args ) is export {
 	my $color = %args.keys ∩ %irc-colors.keys;
 	my $style = %args.keys ∩ %irc-styles.keys;
 	if any($color.elems, $style.elems) > 1 {
@@ -79,7 +79,7 @@ sub ircstyle ( Str $text, *%args ) is export {
 #| styles and colors text. returns a copy.
 #| Colors allowed: white, blue, green, red, brown, purple, orange, yellow, light_green, teal,
 #| light_cyan, light_blue, pink, grey, light_grey.
-sub irc-style-text ( Str $text is copy, :$style? = 0, :$color? = 0, :$bgcolor? = 0 ) returns Str is export {
+sub irc-style-text ( Str() $text is copy, :$style? = 0, :$color? = 0, :$bgcolor? = 0 ) returns Str is export {
 	if $color or $bgcolor {
 		if $color and $bgcolor {
 			$text = %irc-styles<color> ~ %irc-colors{$color} ~ ',' ~ %irc-colors{$bgcolor} ~ $text ~ %irc-styles<reset>;
@@ -97,7 +97,7 @@ sub irc-style-text ( Str $text is copy, :$style? = 0, :$color? = 0, :$bgcolor? =
 }
 #| Convert ANSI style/colored text from your terminal output to IRC styled/colored text.
 #| Supports both foreground and background color, as well as italic, underline and bold.
-sub ansi-to-irc (Str $text is copy) is export returns Str {
+sub ansi-to-irc (Str() $text is copy) is export returns Str {
 	my $escape = "\e[";
 	my $end = 'm';
 	if $text ~~ /$escape/ {

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A plugin to style and color text for IRC. It can also convert the ANSIColor text
 
 ### sub ircstyle
 
-```
+```perl6
 sub ircstyle(
-    Str $text, 
+    Str() $text,
     *%args
 ) returns Mu
 ```
@@ -16,9 +16,9 @@ a shortened function. Like irc-style-text but you can use shorter versions like 
 
 ### sub irc-style-text
 
-```
+```perl6
 sub irc-style-text(
-    Str $text is copy, 
+    Str() $text is copy, 
     :$style = 0, 
     :$color = 0, 
     :$bgcolor = 0
@@ -29,9 +29,9 @@ styles and colors text. returns a copy. Colors allowed: white, blue, green, red,
 
 ### sub ansi-to-irc
 
-```
+```perl6
 sub ansi-to-irc(
-    Str $text is copy
+    Str() $text is copy
 ) returns Str
 ```
 

--- a/t/01-ansi-to-irc.t
+++ b/t/01-ansi-to-irc.t
@@ -1,9 +1,10 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-plan 1;
+plan 2;
 use lib '.';
 use IRC::TextColor;
 my $ansi = slurp 't/01-ansi.txt';
 my $irc = slurp 't/01-irc.txt';
 is ansi-to-irc($ansi), $irc, "ANSI to irc conversion works";
+is-deeply ansi-to-irc(42), '42', 'ansi-to-irc can take a Cool';

--- a/t/02-irc-style-text.t
+++ b/t/02-irc-style-text.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-plan 4;
+plan 6;
 use lib '.';
 use IRC::TextColor;
 
@@ -10,3 +10,5 @@ is irc-style-text('text', :style<bold>, :color<teal>, :bgcolor<blue>), $irc, "ir
 is ircstyle('text', :bold, :teal), irc-style-text('text', :color('teal'), :style('bold')), "ircstyle works with bold and color";
 is ircstyle('text', :bold), irc-style-text('text', :style('bold')), "ircstyle works with just bold";
 is ircstyle('text', :teal), irc-style-text('text', :color('teal')), "ircstyle texts with just color";
+is-deeply irc-style-text(42), '42', 'irc-style-text can take a Cool';
+is-deeply ircstyle(42),       '42', 'ircstyle can take a Cool';


### PR DESCRIPTION
- Coerce to Str() rather than forcing the user to do the coersion
- Helps avoid crashes when text to style is, say, an Int instead of Str
- (also highlight README codes as Perl 6 code)